### PR TITLE
Set old hash replaced flag to the entity object.

### DIFF
--- a/app/code/community/Ikonoshirt/Pbkdf2/Model/Observer.php
+++ b/app/code/community/Ikonoshirt/Pbkdf2/Model/Observer.php
@@ -56,6 +56,7 @@ class Ikonoshirt_Pbkdf2_Model_Observer
             $password, $customer->getPasswordHash()
         )
         ) {
+            $customer->setOldHashReplaced(TRUE);
             $customer->setPassword($password);
             $customer->save();
         }
@@ -85,6 +86,7 @@ class Ikonoshirt_Pbkdf2_Model_Observer
         $user = $observer->getModel();
         $password = $observer->getApiKey();
         if ($encrypter->validateLegacyHash($password, $user->getApiKey())) {
+            $user->setOldHashReplaced(TRUE);
             $user->setApiKey($observer->getApiKey());
             $user->save();
         }
@@ -110,6 +112,7 @@ class Ikonoshirt_Pbkdf2_Model_Observer
         $user = $observer->getUser();
         $password = $observer->getPassword();
         if ($encrypter->validateLegacyHash($password, $user->getPassword())) {
+            $user->setOldHashReplaced(TRUE);
             $user->setPassword($observer->getPassword());
             $user->save();
         }


### PR DESCRIPTION
Set old hash replaced flag to the entity object so it can be used before/after the object save.